### PR TITLE
New argument provided for output

### DIFF
--- a/Code/Optimiser.py
+++ b/Code/Optimiser.py
@@ -83,14 +83,20 @@ class Optimizer_Calculation:
         
         return collected_result
     
-    def write_to_file(self, result_dictionary, SHAPE2, SURVEY, TYPE, SHAPE, MODEL, is_series, Param):
-        if not os.path.exists("output"):
+    def write_to_file(self, result_dictionary, SHAPE2, SURVEY, TYPE, SHAPE, MODEL, is_series, Param, path_to_output):
+        
+        if path_to_output is None and not os.path.exists("output"):
             os.mkdir("output")
+            file_name = "output/"
+        elif not os.path.exists(''.join([path_to_output,"/output"])):
+            os.mkdir(''.join([path_to_output, "/output"]))
+            file_name = ''.join([path_to_output, "/output/"])
+        
+        file_name = ''.join([file_name, '_'.join([TYPE, SHAPE, MODEL, Param])])
 
-        file_name = "output/" + TYPE + "_" + SHAPE + "_" +  MODEL + "_" + Param
-        for survey in SURVEY:
-            file_name += "_" + survey
-        file_name += ".tsv" 
+        file_name = '_'.join([file_name, '_'.join(SURVEY)])
+
+        file_name = ''.join([file_name, ".tsv"])
 
         with open(file_name, mode='w', newline='\n') as outFile:
             outFileWriter = csv.writer(outFile, delimiter = '\t')


### PR DESCRIPTION
For #12 

Changes:

- updated write_to_file to take a filepath to write to. If none is provided, it will write to the directory the program is in
- updated write_to_file to use string .join() method (its just faster/more pythonic)

- removed os.getenv check from Population_Driver.py; it was always erroring for me because that arg would never have been valid
- added a string type checker for IT argument. If it's a default boolean, it'll throw an error trying to convert a boolean to a boolean. (Also, why aren't we using casting here?)
- added "--OUTDIR" arg, with a default being whatever dir the program is in.